### PR TITLE
feat(effects-ng): export injection tokens

### DIFF
--- a/libs/effects-ng/src/index.ts
+++ b/libs/effects-ng/src/index.ts
@@ -3,6 +3,7 @@ export { Actions } from './lib/actions';
 export { EffectFn } from './lib/effect-fn';
 export { provideEffects } from './lib/provide-effects';
 export { provideEffectsManager } from './lib/provide-effects-manager';
+export { EFFECTS_MANAGER, EFFECTS_PROVIDERS } from './lib/tokens';
 export {
   provideDirectiveEffects,
   EffectsDirective,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/effects/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

By `provideEffectsManager`, we provide an instance of `EffectsManager` to the token `EFFECTS_MANAGER`, but the token is not exposed.

When creating utility wrappers upon this library, the `EffectsManager` instance can be used to register effects, but as the token is not exposed, it can be pretty troublesome to inject the instance.

As an workaround, the user can use the `registerEffects` function exported from theh `@ngneat/effects` package, but it makes the code feel un-Angular and it also require the user to check the implementation details.

Issue Number: N/A

## What is the new behavior?

The injection tokens are now exported in index so that the user can have access to the provided `EffectsManager` instance.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
